### PR TITLE
Turn off tests related to sampling when shots=0 in the Braket device

### DIFF
--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Run PennyLane device integration tests
         run: |
-          pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000
-          pl-device-test --device=braket.local.qubit --tb=short --skip-ops
+          pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'
+          pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -55,8 +55,8 @@ jobs:
           if ! [ -x "$(command -v pl-device-test)" ]; then
             echo 'Error: Version of PennyLane does not provide device integration tests.' >&2
           else
-            pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000
-            pl-device-test --device=braket.local.qubit --tb=short --skip-ops
+            pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'
+            pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
           fi
 
       - name: Run plugin tests

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Run PennyLane device integration tests
         run: |
-          pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000
-          pl-device-test --device=braket.local.qubit --tb=short --skip-ops
+          pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'
+          pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -62,8 +62,8 @@ jobs:
           if ! [ -x "$(command -v pl-device-test)" ]; then
             echo 'Error: Version of PennyLane does not provide device integration tests.' >&2
           else
-            pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000
-            pl-device-test --device=braket.local.qubit --tb=short --skip-ops
+            pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'
+            pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
           fi
 
       - name: Run plugin tests

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ All entries in the matrix are tested against PennyLane latest (GitHub master).
 
 * The device integration tests currently do not support devices with a fixed
   number of wires; as a result, `forest.qvm` is not tested.
+  
+* The Braket plugin device integration tests are run with `-k “not Sample and not no_0_shots”`,
+  see #6
 
 ## Interpreting the test matrix
 

--- a/compile.py
+++ b/compile.py
@@ -123,8 +123,8 @@ workflows = [
         "device_tests": [],
         "branch": "main",
         "device_tests": [
-            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000",
-            "--device=braket.local.qubit --tb=short --skip-ops",
+            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'",
+            "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",
     },

--- a/compile.py
+++ b/compile.py
@@ -123,7 +123,7 @@ workflows = [
         "device_tests": [],
         "branch": "main",
         "device_tests": [
-            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k'not no_0_shots'",
+            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'",
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",

--- a/compile.py
+++ b/compile.py
@@ -123,7 +123,7 @@ workflows = [
         "device_tests": [],
         "branch": "main",
         "device_tests": [
-            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'not no_0_shots'",
+            "--device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k'not no_0_shots'",
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",


### PR DESCRIPTION
Consider the errors from the Braket device: (shown in https://github.com/PennyLaneAI/plugin-test-matrix/pull/4).
There are two PRs to fix the wires and probabilities-based errors:
https://github.com/aws/amazon-braket-pennylane-plugin-python/pull/55
https://github.com/aws/amazon-braket-pennylane-plugin-python/pull/56

However, the sampling based errors still remain. Specifically, we get an error for `test_no_0_shots` because the Braket device does not raise an error when 0 shots are specified. In fact, specifying 0 shots is the method to make the device become analytic.

Also, we get an error for the `TestSample` and `TestTensorSample` tests when `shots` is unspecified. This is because the shots defaults to zero (analytic mode), but we then ask the braket SDK to perform sampling with zero shots. The behaviour is different to core PL, where a device can be in analytic mode but still returns a default 1000 shots.

My initial reaction was to fix these errors. However, we recently decided to [update the shots](https://github.com/PennyLaneAI/adrs/blob/master/documents/035-shots.rst) behaviour in PL and have committed to carrying this out in the current quarter. The planned new behaviour is very similar to the Braket device now: `shots` will be the only source of truth for whether the device is in analytic mode or not.

I think rather than fixing the Braket device to work with PL's current shots behaviour, we should wait until the shots refactor has been implemented.