### PR TITLE
Add TensorFlow as a requirement when running the PennyLane-SF tests

### DIFF
--- a/.github/workflows/sf-latest-latest.yml
+++ b/.github/workflows/sf-latest-latest.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade strawberryfields
+          pip install --upgrade tensorflow
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/sf-latest-stable.yml
+++ b/.github/workflows/sf-latest-stable.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade strawberryfields
+          pip install --upgrade tensorflow
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/sf-stable-latest.yml
+++ b/.github/workflows/sf-stable-latest.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade strawberryfields
+          pip install --upgrade tensorflow
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/sf-stable-stable.yml
+++ b/.github/workflows/sf-stable-stable.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade strawberryfields
+          pip install --upgrade tensorflow
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/compile.py
+++ b/compile.py
@@ -47,7 +47,7 @@ workflows = [
         "plugin": "sf",
         "gh_user": "PennyLaneAI",
         "which": ["stable", "latest"],
-        "requirements": ["strawberryfields"],
+        "requirements": ["strawberryfields", "tensorflow"],
         "device_tests": [],
     },
     {


### PR DESCRIPTION
The TensorFlow device tests seem to be skipped when running the device test suite, as TF is not being installed. This might lead to test failures going unnoticed when looking at the test suite (e.g., [see this log](https://github.com/PennyLaneAI/pennylane-sf/runs/3736358267#step:7:35)).

This PR adds TF as a requirement to running the PennyLane-SF tests.