### PR TITLE
Remove `@master` branch pinning for latest workflows due to `pip` conflicts

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/forest-latest-latest.yml
+++ b/.github/workflows/forest-latest-latest.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/forest-stable-latest.yml
+++ b/.github/workflows/forest-stable-latest.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/honeywell-latest-latest.yml
+++ b/.github/workflows/honeywell-latest-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/honeywell-stable-latest.yml
+++ b/.github/workflows/honeywell-stable-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/lightning-latest-latest.yml
+++ b/.github/workflows/lightning-latest-latest.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/lightning-stable-latest.yml
+++ b/.github/workflows/lightning-stable-latest.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/orquestra-latest-latest.yml
+++ b/.github/workflows/orquestra-latest-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/orquestra-stable-latest.yml
+++ b/.github/workflows/orquestra-stable-latest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/pq-latest-latest.yml
+++ b/.github/workflows/pq-latest-latest.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/pq-stable-latest.yml
+++ b/.github/workflows/pq-stable-latest.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/.github/workflows/sf-latest-latest.yml
+++ b/.github/workflows/sf-latest-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/sf-stable-latest.yml
+++ b/.github/workflows/sf-stable-latest.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@${{ env.PENNYLANE_BRANCH }} \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git \
           ${{ env.PLUGIN_PACKAGE }} --upgrade
 
       - name: Get plugin version

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -13,7 +13,7 @@ env:
   PLUGIN_REPO: {{ gh_user }}/{{ plugin_repo }}
   PLUGIN_BRANCH: {% if branch %}{{ branch }}{% else %}master{% endif %}
   PLUGIN_PACKAGE: {{ plugin_package }}
-  #PENNYLANE_BRANCH: @master
+  PENNYLANE_BRANCH: master
   IBMQX_TOKEN: {% raw %}${{ secrets.IBMQX_TOKEN }}{% endraw %}
   IONQ_API_KEY: {% raw %}${{ secrets.IONQ_API_KEY }}{% endraw %}
 


### PR DESCRIPTION
**Context**

At the moment, in the latest workflows we are pinning to the master branch explicitly using the `@master` suffix when specifying the URL for PennyLane.

`pip` can, however, produce dependency conflicts when a plugin pins PennyLane without the `@master` suffix. This is the case now for the [PennyLane-SF plugin](https://github.com/PennyLaneAI/plugin-test-matrix/runs/3883242440?check_suite_focus=true#step:5:55).

**Changes**

Removes the `@master` suffix when requesting PennyLane in the latest plugin workflows.

This ensures that several components in our ecosystem work well together, provided we pin to the `master` branch of PennyLane  using the `git+git://github.com/PennyLaneAI/pennylane` syntax:
* Plugins (e.g., [PennyLane-SF atm](https://github.com/PennyLaneAI/pennylane-sf/blob/d5188553bdb19ee758a0464cfdc08e19505bcd06/requirements.txt#L2));
* QML repo ([`dev` branch requirements](https://github.com/PennyLaneAI/qml/blob/dev/requirements.txt#L14));
* `plugin-test-matrix` (with this PR).