### PR TITLE
Pin Pyquil version in the workflow

### DIFF
--- a/.github/workflows/forest-latest-latest.yml
+++ b/.github/workflows/forest-latest-latest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil
+          pip install --upgrade pyquil==2.28.3
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-latest-latest.yml
+++ b/.github/workflows/forest-latest-latest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil==2.28.3
+          pip install --upgrade pyquil==2.28.2
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-latest-stable.yml
+++ b/.github/workflows/forest-latest-stable.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil
+          pip install --upgrade pyquil==2.28.3
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-latest-stable.yml
+++ b/.github/workflows/forest-latest-stable.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil==2.28.3
+          pip install --upgrade pyquil==2.28.2
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-stable-latest.yml
+++ b/.github/workflows/forest-stable-latest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil
+          pip install --upgrade pyquil==2.28.3
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-stable-latest.yml
+++ b/.github/workflows/forest-stable-latest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil==2.28.3
+          pip install --upgrade pyquil==2.28.2
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-stable-stable.yml
+++ b/.github/workflows/forest-stable-stable.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil
+          pip install --upgrade pyquil==2.28.3
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/forest-stable-stable.yml
+++ b/.github/workflows/forest-stable-stable.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade pyquil==2.28.3
+          pip install --upgrade pyquil==2.28.2
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/compile.py
+++ b/compile.py
@@ -54,7 +54,7 @@ workflows = [
         "plugin": "forest",
         "gh_user": "rigetti",
         "which": ["stable", "latest"],
-        "requirements": ["pyquil==2.28.3"],
+        "requirements": ["pyquil==2.28.2"],
         "device_tests": [
             "--device=forest.numpy_wavefunction --tb=short --skip-ops --shots=None",
             "--device=forest.wavefunction --tb=short --skip-ops --shots=20000",

--- a/compile.py
+++ b/compile.py
@@ -54,7 +54,7 @@ workflows = [
         "plugin": "forest",
         "gh_user": "rigetti",
         "which": ["stable", "latest"],
-        "requirements": ["pyquil"],
+        "requirements": ["pyquil==2.28.3"],
         "device_tests": [
             "--device=forest.numpy_wavefunction --tb=short --skip-ops --shots=None",
             "--device=forest.wavefunction --tb=short --skip-ops --shots=20000",


### PR DESCRIPTION
We pin the Pyquil version to pyquil==2.28.2, because we do not support Pyquil 3.0. As it is pinned in the forest plugin, we could now find bug not related to the 3.0 version.