### PR TITLE
Change name IBMQ token env name and remove IBMQ/runtime tests

### DIFF
--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -64,3 +64,4 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -63,4 +63,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -14,7 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
+  IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -66,3 +66,4 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -65,4 +65,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -14,7 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
+  IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -70,3 +70,4 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -69,4 +69,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -14,7 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
+  IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -72,4 +72,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -73,3 +73,4 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -14,7 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
+  IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 


### PR DESCRIPTION
Some PennyLane Qiskit tests are not run because the env name of the token is not the same in the CI checks and in the plugin matrix, we replace `IBMQX_TOKEN` by `IBMQX_TOKEN_TEST`. 

We also remove IBMQ and runtime tests from the tests run, because using IBMQ can result in timeouts easily when using the CI.