### PR TITLE
Change ubuntu version for lightning

### DIFF
--- a/.github/workflows/lightning-latest-latest.yml
+++ b/.github/workflows/lightning-latest-latest.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lightning-latest-stable.yml
+++ b/.github/workflows/lightning-latest-stable.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lightning-stable-latest.yml
+++ b/.github/workflows/lightning-stable-latest.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lightning-stable-stable.yml
+++ b/.github/workflows/lightning-stable-stable.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
 Ubuntu 22.04 is required because GCC 10+ is needed for Lightning.