### PR TITLE
Only trigger with push if on master branch.

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -3,6 +3,8 @@
 name: aqt-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -3,6 +3,8 @@
 name: aqt-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/aqt-latest-stable.yml
+++ b/.github/workflows/aqt-latest-stable.yml
@@ -3,6 +3,8 @@
 name: aqt-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -3,6 +3,8 @@
 name: aqt-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/aqt-stable-stable.yml
+++ b/.github/workflows/aqt-stable-stable.yml
@@ -3,6 +3,8 @@
 name: aqt-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -3,6 +3,8 @@
 name: braket-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -3,6 +3,8 @@
 name: braket-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -3,6 +3,8 @@
 name: braket-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -3,6 +3,8 @@
 name: braket-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -3,6 +3,8 @@
 name: braket-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -3,6 +3,8 @@
 name: cirq-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -3,6 +3,8 @@
 name: cirq-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -3,6 +3,8 @@
 name: cirq-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -3,6 +3,8 @@
 name: cirq-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -3,6 +3,8 @@
 name: cirq-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/honeywell-latest-latest.yml
+++ b/.github/workflows/honeywell-latest-latest.yml
@@ -3,6 +3,8 @@
 name: honeywell-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/honeywell-latest-rc.yml
+++ b/.github/workflows/honeywell-latest-rc.yml
@@ -3,6 +3,8 @@
 name: honeywell-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/honeywell-latest-stable.yml
+++ b/.github/workflows/honeywell-latest-stable.yml
@@ -3,6 +3,8 @@
 name: honeywell-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/honeywell-stable-latest.yml
+++ b/.github/workflows/honeywell-stable-latest.yml
@@ -3,6 +3,8 @@
 name: honeywell-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/honeywell-stable-stable.yml
+++ b/.github/workflows/honeywell-stable-stable.yml
@@ -3,6 +3,8 @@
 name: honeywell-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -3,6 +3,8 @@
 name: ionq-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -3,6 +3,8 @@
 name: ionq-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/ionq-latest-stable.yml
+++ b/.github/workflows/ionq-latest-stable.yml
@@ -3,6 +3,8 @@
 name: ionq-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -3,6 +3,8 @@
 name: ionq-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -3,6 +3,8 @@
 name: ionq-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/lightning-latest-latest.yml
+++ b/.github/workflows/lightning-latest-latest.yml
@@ -3,6 +3,8 @@
 name: lightning-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -3,6 +3,8 @@
 name: lightning-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/lightning-latest-stable.yml
+++ b/.github/workflows/lightning-latest-stable.yml
@@ -3,6 +3,8 @@
 name: lightning-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/lightning-stable-latest.yml
+++ b/.github/workflows/lightning-stable-latest.yml
@@ -3,6 +3,8 @@
 name: lightning-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/lightning-stable-stable.yml
+++ b/.github/workflows/lightning-stable-stable.yml
@@ -3,6 +3,8 @@
 name: lightning-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/orquestra-latest-latest.yml
+++ b/.github/workflows/orquestra-latest-latest.yml
@@ -3,6 +3,8 @@
 name: orquestra-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/orquestra-latest-rc.yml
+++ b/.github/workflows/orquestra-latest-rc.yml
@@ -3,6 +3,8 @@
 name: orquestra-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/orquestra-latest-stable.yml
+++ b/.github/workflows/orquestra-latest-stable.yml
@@ -3,6 +3,8 @@
 name: orquestra-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/orquestra-stable-latest.yml
+++ b/.github/workflows/orquestra-stable-latest.yml
@@ -3,6 +3,8 @@
 name: orquestra-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/orquestra-stable-stable.yml
+++ b/.github/workflows/orquestra-stable-stable.yml
@@ -3,6 +3,8 @@
 name: orquestra-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/pq-latest-latest.yml
+++ b/.github/workflows/pq-latest-latest.yml
@@ -3,6 +3,8 @@
 name: pq-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/pq-latest-rc.yml
+++ b/.github/workflows/pq-latest-rc.yml
@@ -3,6 +3,8 @@
 name: pq-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/pq-latest-stable.yml
+++ b/.github/workflows/pq-latest-stable.yml
@@ -3,6 +3,8 @@
 name: pq-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/pq-stable-latest.yml
+++ b/.github/workflows/pq-stable-latest.yml
@@ -3,6 +3,8 @@
 name: pq-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/pq-stable-stable.yml
+++ b/.github/workflows/pq-stable-stable.yml
@@ -3,6 +3,8 @@
 name: pq-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -3,6 +3,8 @@
 name: qiskit-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -3,6 +3,8 @@
 name: qiskit-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -3,6 +3,8 @@
 name: qiskit-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -3,6 +3,8 @@
 name: qiskit-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -3,6 +3,8 @@
 name: qiskit-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/quantuminspire-latest-latest.yml
+++ b/.github/workflows/quantuminspire-latest-latest.yml
@@ -3,6 +3,8 @@
 name: quantuminspire-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/quantuminspire-latest-rc.yml
+++ b/.github/workflows/quantuminspire-latest-rc.yml
@@ -3,6 +3,8 @@
 name: quantuminspire-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/quantuminspire-latest-stable.yml
+++ b/.github/workflows/quantuminspire-latest-stable.yml
@@ -3,6 +3,8 @@
 name: quantuminspire-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/quantuminspire-stable-latest.yml
+++ b/.github/workflows/quantuminspire-stable-latest.yml
@@ -3,6 +3,8 @@
 name: quantuminspire-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/quantuminspire-stable-stable.yml
+++ b/.github/workflows/quantuminspire-stable-stable.yml
@@ -3,6 +3,8 @@
 name: quantuminspire-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -3,6 +3,8 @@
 name: qulacs-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -3,6 +3,8 @@
 name: qulacs-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qulacs-latest-stable.yml
+++ b/.github/workflows/qulacs-latest-stable.yml
@@ -3,6 +3,8 @@
 name: qulacs-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -3,6 +3,8 @@
 name: qulacs-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/qulacs-stable-stable.yml
+++ b/.github/workflows/qulacs-stable-stable.yml
@@ -3,6 +3,8 @@
 name: qulacs-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/rigetti-latest-latest.yml
+++ b/.github/workflows/rigetti-latest-latest.yml
@@ -3,6 +3,8 @@
 name: rigetti-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/rigetti-latest-rc.yml
+++ b/.github/workflows/rigetti-latest-rc.yml
@@ -3,6 +3,8 @@
 name: rigetti-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/rigetti-latest-stable.yml
+++ b/.github/workflows/rigetti-latest-stable.yml
@@ -3,6 +3,8 @@
 name: rigetti-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -3,6 +3,8 @@
 name: rigetti-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/rigetti-stable-stable.yml
+++ b/.github/workflows/rigetti-stable-stable.yml
@@ -3,6 +3,8 @@
 name: rigetti-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/sf-latest-latest.yml
+++ b/.github/workflows/sf-latest-latest.yml
@@ -3,6 +3,8 @@
 name: sf-latest-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/sf-latest-rc.yml
+++ b/.github/workflows/sf-latest-rc.yml
@@ -3,6 +3,8 @@
 name: sf-latest-rc
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/sf-latest-stable.yml
+++ b/.github/workflows/sf-latest-stable.yml
@@ -3,6 +3,8 @@
 name: sf-latest-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/sf-stable-latest.yml
+++ b/.github/workflows/sf-stable-latest.yml
@@ -3,6 +3,8 @@
 name: sf-stable-latest
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/sf-stable-stable.yml
+++ b/.github/workflows/sf-stable-stable.yml
@@ -3,6 +3,8 @@
 name: sf-stable-stable
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
**Context:**
It seems all workflows are run twice when a PR is made, once because there is a `push` and once because the push is part of a `pull_request`. 

**Description of the Change:**
Only trigger workflows when there is a `push` to `master`.

**Benefits:**
Half CI times.

**Possible Drawbacks:**
We may want to trigger the CI when pushing to non-`master` branches outside a PR.

**Related GitHub Issues:**
None.
