### PR TITLE
Workflow fix-ups

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/aqt-latest-stable.yml
+++ b/.github/workflows/aqt-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/aqt-stable-stable.yml
+++ b/.github/workflows/aqt-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -19,6 +19,7 @@ env:
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -36,16 +37,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+            
+      - name: Install TF
+        run: |
+          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
-
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane and Plugin
         run: |

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+            
+      - name: Install TF
+        run: |
+          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
-
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane and Plugin
         run: |

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+            
+      - name: Install TF
+        run: |
+          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
-
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane and Plugin
         run: |

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+            
+      - name: Install TF
+        run: |
+          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
-
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane and Plugin
         run: |

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   TF_VERSION: 2.6.0
   TORCH_VERSION: 1.10.0+cpu
 

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+            
+      - name: Install TF
+        run: |
+          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
-
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane and Plugin
         run: |

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_cirq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_cirq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_cirq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_cirq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_cirq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/ensure_compiled.yml
+++ b/.github/workflows/ensure_compiled.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Compile and check for changes files
-        run: python compile.py && git diff-index --quiet HEAD
+        run: python compile.py && git diff --quiet

--- a/.github/workflows/ensure_compiled.yml
+++ b/.github/workflows/ensure_compiled.yml
@@ -1,0 +1,15 @@
+name: Ensure templates are not manually changed
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  check-diff:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Compile and check for changes files
+        run: python compile.py && git diff-index --quiet HEAD

--- a/.github/workflows/ensure_compiled.yml
+++ b/.github/workflows/ensure_compiled.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-diff:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/honeywell-latest-latest.yml
+++ b/.github/workflows/honeywell-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_honeywell
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/honeywell-latest-rc.yml
+++ b/.github/workflows/honeywell-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_honeywell
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/honeywell-latest-stable.yml
+++ b/.github/workflows/honeywell-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_honeywell
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/honeywell-stable-latest.yml
+++ b/.github/workflows/honeywell-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_honeywell
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/honeywell-stable-stable.yml
+++ b/.github/workflows/honeywell-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_honeywell
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -14,7 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_ionq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -14,7 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_ionq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/ionq-latest-stable.yml
+++ b/.github/workflows/ionq-latest-stable.yml
@@ -14,7 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_ionq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -14,7 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_ionq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -14,7 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_ionq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
   IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 

--- a/.github/workflows/lightning-latest-latest.yml
+++ b/.github/workflows/lightning-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_lightning
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   GCC_VERSION: 11
 
 

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_lightning
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   GCC_VERSION: 11
 
 

--- a/.github/workflows/lightning-latest-stable.yml
+++ b/.github/workflows/lightning-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_lightning
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   GCC_VERSION: 11
 
 

--- a/.github/workflows/lightning-stable-latest.yml
+++ b/.github/workflows/lightning-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_lightning
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   GCC_VERSION: 11
 
 

--- a/.github/workflows/lightning-stable-stable.yml
+++ b/.github/workflows/lightning-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_lightning
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   GCC_VERSION: 11
 
 

--- a/.github/workflows/orquestra-latest-latest.yml
+++ b/.github/workflows/orquestra-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: pennylane_orquestra
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/orquestra-latest-rc.yml
+++ b/.github/workflows/orquestra-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: pennylane_orquestra
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/orquestra-latest-stable.yml
+++ b/.github/workflows/orquestra-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: pennylane_orquestra
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/orquestra-stable-latest.yml
+++ b/.github/workflows/orquestra-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: pennylane_orquestra
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/orquestra-stable-stable.yml
+++ b/.github/workflows/orquestra-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: pennylane_orquestra
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-latest.yml
+++ b/.github/workflows/pq-latest-latest.yml
@@ -14,6 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
+  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-latest.yml
+++ b/.github/workflows/pq-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-rc.yml
+++ b/.github/workflows/pq-latest-rc.yml
@@ -14,6 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
+  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-rc.yml
+++ b/.github/workflows/pq-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-stable.yml
+++ b/.github/workflows/pq-latest-stable.yml
@@ -14,6 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
+  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
 
 
 jobs:

--- a/.github/workflows/pq-latest-stable.yml
+++ b/.github/workflows/pq-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/pq-stable-latest.yml
+++ b/.github/workflows/pq-stable-latest.yml
@@ -14,6 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
+  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
 
 
 jobs:

--- a/.github/workflows/pq-stable-latest.yml
+++ b/.github/workflows/pq-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/pq-stable-stable.yml
+++ b/.github/workflows/pq-stable-stable.yml
@@ -14,6 +14,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
+  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
 
 
 jobs:

--- a/.github/workflows/pq-stable-stable.yml
+++ b/.github/workflows/pq-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_pq
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -64,4 +64,3 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
-        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -62,4 +62,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -15,7 +15,6 @@ env:
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
   IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -64,4 +64,3 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
-        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -62,4 +62,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -15,7 +15,6 @@ env:
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
   IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -66,4 +66,3 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
-        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -64,4 +64,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -15,7 +15,6 @@ env:
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
   IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -68,4 +68,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -70,4 +70,3 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
-        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -15,7 +15,6 @@ env:
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
   IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -73,4 +73,3 @@ jobs:
 
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
-        # Tests are removed because they are run on IBMQ

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -71,4 +71,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -k 'not test_ibmq.py and not test_runtime.py' --tb=short
+        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -15,7 +15,6 @@ env:
   PLUGIN_PACKAGE: pennylane_qiskit
   PENNYLANE_BRANCH: master
   IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/quantuminspire-latest-latest.yml
+++ b/.github/workflows/quantuminspire-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_quantuminspire
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   QI_TOKEN: ${{ secrets.QI_TOKEN }}
 
 

--- a/.github/workflows/quantuminspire-latest-rc.yml
+++ b/.github/workflows/quantuminspire-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_quantuminspire
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   QI_TOKEN: ${{ secrets.QI_TOKEN }}
 
 

--- a/.github/workflows/quantuminspire-latest-stable.yml
+++ b/.github/workflows/quantuminspire-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_quantuminspire
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   QI_TOKEN: ${{ secrets.QI_TOKEN }}
 
 

--- a/.github/workflows/quantuminspire-stable-latest.yml
+++ b/.github/workflows/quantuminspire-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_quantuminspire
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   QI_TOKEN: ${{ secrets.QI_TOKEN }}
 
 

--- a/.github/workflows/quantuminspire-stable-stable.yml
+++ b/.github/workflows/quantuminspire-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_quantuminspire
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
   QI_TOKEN: ${{ secrets.QI_TOKEN }}
 
 

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qulacs
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qulacs
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qulacs-latest-stable.yml
+++ b/.github/workflows/qulacs-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qulacs
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qulacs
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/qulacs-stable-stable.yml
+++ b/.github/workflows/qulacs-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_qulacs
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/rigetti-latest-latest.yml
+++ b/.github/workflows/rigetti-latest-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_rigetti
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/rigetti-latest-rc.yml
+++ b/.github/workflows/rigetti-latest-rc.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_rigetti
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/rigetti-latest-stable.yml
+++ b/.github/workflows/rigetti-latest-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_rigetti
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_rigetti
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/.github/workflows/rigetti-stable-stable.yml
+++ b/.github/workflows/rigetti-stable-stable.yml
@@ -14,8 +14,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_rigetti
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-  IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ Simply add a new plugin to the `workflows` list in [`compile.py`](compile.py), w
 
 * `runs_on` (optional): string to override the workflow's default `runs-on` attribute of `ubuntu-latest`.
 
-* `test_filter` (optional): string passed to pytest's "-k" option to filter tests run. Note that it is not quoted,
-  so you should wrap it in the appropriate quote types to ensure no syntax errors are raised.
+* `test_kwargs` (optional): additional arguments to pass to pytest for the given plugin.
 
 Once you have added your plugin, run
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ Simply add a new plugin to the `workflows` list in [`compile.py`](compile.py), w
 * `token` (optional): sets an environment variable with the same name as the token. The value is loaded from the
   repository secrets. The token is required by some plugins for backend authentication.
 
+* `additional_env_vars` (optional): string containing additional environment variables you'd like to be set for
+  the CI action. Double-check the whitespace when using this - variables should be separated with "\n  "
+
+* `runs_on` (optional): string to override the workflow's default `runs-on` attribute of `ubuntu-latest`.
+
+* `test_filter` (optional): string passed to pytest's "-k" option to filter tests run. Note that it is not quoted,
+  so you should wrap it in the appropriate quote types to ensure no syntax errors are raised.
+
 Once you have added your plugin, run
 
 ```console

--- a/compile.py
+++ b/compile.py
@@ -16,6 +16,7 @@ workflows = [
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary",
         ],
         "test_filter": "'not test_ibmq.py and not test_runtime.py'",
+        "token": "IBMQX_TOKEN",
     },
     {
         "plugin": "cirq",
@@ -82,6 +83,7 @@ workflows = [
         "which": ["stable", "latest"],
         "requirements": [],
         "device_tests": ["--device=ionq.simulator --tb=short --skip-ops --shots=10000"],
+        "token": "IONQ_API_KEY",
     },
     {
         "plugin": "pq",

--- a/compile.py
+++ b/compile.py
@@ -91,6 +91,7 @@ workflows = [
         "which": ["stable", "latest"],
         "requirements": ["projectq"],
         "device_tests": [],
+        "token": "IBMQX_TOKEN",
     },
     {
         "plugin": "lightning",

--- a/compile.py
+++ b/compile.py
@@ -15,7 +15,7 @@ workflows = [
             "--device=qiskit.basicaer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary",
         ],
-        "test_filter": "'not test_ibmq.py and not test_runtime.py'",
+        "test_kwargs": ["-k 'not test_ibmq.py and not test_runtime.py'"],
         "token": "IBMQX_TOKEN",
     },
     {

--- a/compile.py
+++ b/compile.py
@@ -15,6 +15,7 @@ workflows = [
             "--device=qiskit.basicaer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary",
         ],
+        "test_filter": "'not test_ibmq.py and not test_runtime.py'",
     },
     {
         "plugin": "cirq",
@@ -99,10 +100,12 @@ workflows = [
             "--device lightning.qubit --skip-ops --shots=20000",
             ],
         "additional_setup": dedent("""
-            - name: Install Eigen
+            - name: Install buildtools & compilers
               run: |
-                sudo apt install libeigen3-dev"""
-        )
+                sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} ninja-build"""
+        ),
+        "additional_env_vars": "GCC_VERSION: 11",
+        "runs_on": "ubuntu-22.04",
     },
     {
         "plugin": "orquestra",
@@ -127,6 +130,12 @@ workflows = [
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",
+        "additional_setup": dedent("""
+            - name: Install TF
+              run: |
+                pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION"""
+        ),
+        "additional_env_vars": "TF_VERSION: 2.6.0\n  TORCH_VERSION: 1.10.0+cpu",
     },
     {
         "plugin": "quantuminspire",

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -14,9 +14,6 @@ env:
   PLUGIN_BRANCH: {% if branch %}{{ branch }}{% else %}master{% endif %}
   PLUGIN_PACKAGE: {{ plugin_package }}
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: {% raw %}${{ secrets.IBMQX_TOKEN }}{% endraw %}
-  IONQ_API_KEY: {% raw %}${{ secrets.IONQ_API_KEY }}{% endraw %}
-{#- only add the secrets, when token defined in workflow #}
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -105,5 +105,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -20,11 +20,14 @@ env:
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}
+{%- if additional_env_vars is defined %}
+  {{ additional_env_vars }}
+{%- endif %}
 
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: {% if runs_on is defined %}{{ runs_on }}{% else %}ubuntu-latest{% endif %}
 
     strategy:
       fail-fast: false
@@ -105,5 +108,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -14,9 +14,6 @@ env:
   PLUGIN_BRANCH: {% if branch %}{{ branch }}{% else %}master{% endif %}
   PLUGIN_PACKAGE: {{ plugin_package }}
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: {% raw %}${{ secrets.IBMQX_TOKEN }}{% endraw %}
-  IONQ_API_KEY: {% raw %}${{ secrets.IONQ_API_KEY }}{% endraw %}
-{#- only add the secrets, when token defined in workflow #}
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -78,5 +78,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -20,11 +20,14 @@ env:
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}
+{%- if additional_env_vars is defined %}
+  {{ additional_env_vars }}
+{%- endif %}
 
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: {% if runs_on is defined %}{{ runs_on }}{% else %}ubuntu-latest{% endif %}
 
     strategy:
       fail-fast: false
@@ -78,5 +81,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -20,11 +20,14 @@ env:
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}
+{%- if additional_env_vars is defined %}
+  {{ additional_env_vars }}
+{%- endif %}
 
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: {% if runs_on is defined %}{{ runs_on }}{% else %}ubuntu-latest{% endif %}
 
     strategy:
       fail-fast: false
@@ -103,5 +106,5 @@ jobs:
       {%- endif %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -14,9 +14,6 @@ env:
   PLUGIN_BRANCH: {% if branch %}{{ branch }}{% else %}master{% endif %}
   PLUGIN_PACKAGE: {{ plugin_package }}
   PENNYLANE_BRANCH: master
-  IBMQX_TOKEN: {% raw %}${{ secrets.IBMQX_TOKEN }}{% endraw %}
-  IONQ_API_KEY: {% raw %}${{ secrets.IONQ_API_KEY }}{% endraw %}
-{#- only add the secrets, when token defined in workflow #}
 {%- if token is defined %}
   {{ token }}: {% raw %}${{ secrets.{% endraw %}{{ token }}{% raw %} }}{% endraw %}
 {%- endif %}

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -103,5 +103,5 @@ jobs:
       {%- endif %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} {% if test_filter is defined %}-k {{ test_filter }} {% endif %}--tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 


### PR DESCRIPTION
I've noticed that if I run `compile.py` locally, some changes occur. This means people have changed the workflows directly rather than using the templates, thereby making it harder for future devs to run the script (or worded differently, easier for future devs to wipe out necessary changes by accident). I made 2 commits:
1. Move all custom stuff into compile.py and the templates to make sure re-rendering only makes aesthetic changes to include the manual stuff people have added
2. Change Qiskit, PQ (it needs the IBM token) and IonQ tokens to use the new token rendering code Christina added

The next 3 commits add a GitHub action to ensure devs don't manually change files and any updates persist. It just runs `python compile.py && git diff --quiet`. If any files changed, the `--quiet` sets the exit code to 1, and the action will fail.

What's changed in the templates:
- Most template files just have the 2 tokens removed (the 3 plugins mentioned above only have 1 token removed)
- The braket ones just moved the TF import up a couple lines
- The qiskit ones had a comment deleted because it would be too inconvenient to add it to the templates conditionally