### PR TITLE
use pytest-xdist on braket

### DIFF
--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install --upgrade pytest-xdist
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install --upgrade pytest-xdist
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install --upgrade pytest-xdist
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install --upgrade pytest-xdist
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install --upgrade pytest-xdist
           pip install pytest pytest-mock pytest-cov flaky
           pip freeze
 

--- a/compile.py
+++ b/compile.py
@@ -125,7 +125,7 @@ workflows = [
         "plugin_package": "amazon-braket-pennylane-plugin",
         "gh_user": "aws",
         "which": ["stable", "latest"],
-        "requirements": [],
+        "requirements": ["pytest-xdist"],
         "device_tests": [],
         "branch": "main",
         "device_tests": [


### PR DESCRIPTION
Braket [is failing](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/5570471911/jobs/10187141436) because it [requires pytest-xdist](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/setup.cfg#L8) to be installed. We can install it everywhere, but I'm not sure if some plugins fail from multi-threading or not so I figured let's just start here.