### PR TITLE
Raise error for PennyLaneDeprecationWarning in rc tests

### DIFF
--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -57,4 +57,4 @@ jobs:
         run: |
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -66,4 +66,4 @@ jobs:
           pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/test/unit_tests --tb=short
+        run: python -m pytest plugin_repo/test/unit_tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -65,4 +65,4 @@ jobs:
           pl-device-test --device=cirq.qsim --tb=short --skip-ops --analytic=False --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/honeywell-latest-rc.yml
+++ b/.github/workflows/honeywell-latest-rc.yml
@@ -57,4 +57,4 @@ jobs:
         run: |
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -59,4 +59,4 @@ jobs:
           pl-device-test --device=ionq.simulator --tb=short --skip-ops --shots=10000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/pq-latest-rc.yml
+++ b/.github/workflows/pq-latest-rc.yml
@@ -59,4 +59,4 @@ jobs:
         run: |
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -64,4 +64,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short -k 'not test_ibmq.py and not test_runtime.py'

--- a/.github/workflows/quantuminspire-latest-rc.yml
+++ b/.github/workflows/quantuminspire-latest-rc.yml
@@ -62,4 +62,4 @@ jobs:
           pl-device-test --device=quantuminspire.qi --tb=short --skip-ops --shots=4096 --device-kwargs backend='QX single-node simulator'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests/unit_test --tb=short
+        run: python -m pytest plugin_repo/tests/unit_test -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -60,4 +60,4 @@ jobs:
           pl-device-test --device=qulacs.simulator --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/rigetti-latest-rc.yml
+++ b/.github/workflows/rigetti-latest-rc.yml
@@ -66,4 +66,4 @@ jobs:
           pl-device-test --device=rigetti.wavefunction --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -80,5 +80,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }} -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 


### PR DESCRIPTION
Add the same line we have in the standard test matrix tests to the RC tests, so they will mark it as an error if there is a `PennyLaneDeprecationWarning`