### PR TITLE
do not raise deprecation warnings as errors on braket

### DIFF
--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -66,4 +66,4 @@ jobs:
           pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/test/unit_tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -72,4 +72,4 @@ jobs:
           pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/test/unit_tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Simply add a new plugin to the `workflows` list in [`compile.py`](compile.py), w
 
 * `test_kwargs` (optional): additional arguments to pass to pytest for the given plugin.
 
+* `no_deprecation_error` (optional): set to True to not raise PL deprecation warnings as errors when testing
+  the latest version of the plugin. By default, PL deprecation warnings are raised as errors.
+
 Once you have added your plugin, run
 
 ```console

--- a/compile.py
+++ b/compile.py
@@ -110,6 +110,7 @@ workflows = [
                 pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION"""
         ),
         "additional_env_vars": "TF_VERSION: 2.12.0\n  TORCH_VERSION: 2.0.0+cpu",
+        "no_deprecation_error": True,
     },
     {
         "plugin": "quantuminspire",

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -107,5 +107,5 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }} -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: python -m pytest plugin_repo/{{ tests_loc }}{% if no_deprecation_error %}{% else %} -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
 


### PR DESCRIPTION
the errors hide meaningful results in the case of braket tests, so we should stop raising PL deprecation warnings as errors there.

I've added a mechanism to disable it for any plugin, by setting `no_deprecation_error` to `True` (or any value, really) in the plugin's definition in `compile.py`.