### PR TITLE
Pin Qiskit to 0.45.3

### DIFF
--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade qiskit<0.46
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit<0.46
+          pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade qiskit<0.46
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit<0.46
+          pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade qiskit<0.46
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit<0.46
+          pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade qiskit<0.46
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit<0.46
+          pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade qiskit<0.46
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit<0.46
+          pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
           pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze

--- a/compile.py
+++ b/compile.py
@@ -8,7 +8,7 @@ workflows = [
         "plugin": "qiskit",
         "gh_user": "PennyLaneAI",
         "which": ["latest", "stable"],
-        "requirements": ["qiskit", "pyscf"],
+        "requirements": ["qiskit<0.46", "pyscf"],
         "device_tests": [
             "--device=qiskit.basicaer --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=20000",

--- a/compile.py
+++ b/compile.py
@@ -8,7 +8,7 @@ workflows = [
         "plugin": "qiskit",
         "gh_user": "PennyLaneAI",
         "which": ["latest", "stable"],
-        "requirements": ["qiskit<0.46", "pyscf"],
+        "requirements": ["'qiskit<0.46.0'", "pyscf"],
         "device_tests": [
             "--device=qiskit.basicaer --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=20000",


### PR DESCRIPTION
After this, all the tests related to Qiskit should pass. I am 90% certain it doesn't need to be pinned anywhere else. 

This has been added to the shortcut story tracking all the things we need to put back when we release a plugin version compatible with 1.0.