### PR TITLE
Pin pytest to <8.1.0

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/aqt-latest-stable.yml
+++ b/.github/workflows/aqt-latest-stable.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/aqt-stable-stable.yml
+++ b/.github/workflows/aqt-stable-stable.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pytest-xdist
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pytest-xdist
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pytest-xdist
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pytest-xdist
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pytest-xdist
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -41,7 +41,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -41,7 +41,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -41,7 +41,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -41,7 +41,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -41,7 +41,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/ionq-latest-stable.yml
+++ b/.github/workflows/ionq-latest-stable.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pybind11
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -42,7 +42,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -42,7 +42,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -42,7 +42,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -42,7 +42,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -42,7 +42,8 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade 'qiskit<0.46.0'
           pip install --upgrade pyscf
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/quantuminspire-latest-latest.yml
+++ b/.github/workflows/quantuminspire-latest-latest.yml
@@ -43,7 +43,8 @@ jobs:
           pip install --upgrade pennylane-qiskit
           pip install --upgrade quantuminspire
           pip install --upgrade qiskit
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/quantuminspire-latest-rc.yml
+++ b/.github/workflows/quantuminspire-latest-rc.yml
@@ -43,7 +43,8 @@ jobs:
           pip install --upgrade pennylane-qiskit
           pip install --upgrade quantuminspire
           pip install --upgrade qiskit
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/quantuminspire-latest-stable.yml
+++ b/.github/workflows/quantuminspire-latest-stable.yml
@@ -43,7 +43,8 @@ jobs:
           pip install --upgrade pennylane-qiskit
           pip install --upgrade quantuminspire
           pip install --upgrade qiskit
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/quantuminspire-stable-latest.yml
+++ b/.github/workflows/quantuminspire-stable-latest.yml
@@ -43,7 +43,8 @@ jobs:
           pip install --upgrade pennylane-qiskit
           pip install --upgrade quantuminspire
           pip install --upgrade qiskit
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/quantuminspire-stable-stable.yml
+++ b/.github/workflows/quantuminspire-stable-stable.yml
@@ -43,7 +43,8 @@ jobs:
           pip install --upgrade pennylane-qiskit
           pip install --upgrade quantuminspire
           pip install --upgrade qiskit
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade qulacs
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade qulacs
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qulacs-latest-stable.yml
+++ b/.github/workflows/qulacs-latest-stable.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade qulacs
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade qulacs
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/qulacs-stable-stable.yml
+++ b/.github/workflows/qulacs-stable-stable.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade qulacs
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/rigetti-latest-latest.yml
+++ b/.github/workflows/rigetti-latest-latest.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pyquil==2.28.2
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/rigetti-latest-rc.yml
+++ b/.github/workflows/rigetti-latest-rc.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pyquil==2.28.2
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/rigetti-latest-stable.yml
+++ b/.github/workflows/rigetti-latest-stable.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pyquil==2.28.2
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pyquil==2.28.2
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/rigetti-stable-stable.yml
+++ b/.github/workflows/rigetti-stable-stable.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade pyquil==2.28.2
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -57,7 +57,8 @@ jobs:
           pip install --upgrade {{ req }}
           {%- endfor %}
           {%- endif %}
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
      {%- if latest %}

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -57,7 +57,8 @@ jobs:
           pip install --upgrade {{ req }}
           {%- endfor %}
           {%- endif %}
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0'  
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -52,7 +52,8 @@ jobs:
           {%- for req in requirements %}
           pip install --upgrade {{ req }}
           {%- endfor %}
-          pip install pytest pytest-mock pytest-cov flaky pytest-benchmark
+          pip install 'pytest<8.1.0' 
+          pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
      {%- if latest %}


### PR DESCRIPTION
Incompatibility between flaky and the latest changes to pytest (released yesterday) is causing test failures. Pinning to below the newest version of pytest until resolved.

The remaining failures (`QuantumInspire` across the board, `Braket` latest/latest, and `Qiskit` stable/latest) are expected.