### PR TITLE
Update test matrix according to changes to PL-Qiskit plugin

### DIFF
--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -65,4 +65,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -65,4 +65,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests --tb=short

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -67,4 +67,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests --tb=short

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -71,4 +71,4 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -74,4 +74,4 @@ jobs:
           fi
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests --tb=short -k 'not test_ibmq.py and not test_runtime.py'
+        run: python -m pytest plugin_repo/tests --tb=short

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ All entries in the matrix are tested against PennyLane latest (GitHub master).
 * The Braket plugin device integration tests are run with `-k “not Sample and not no_0_shots”`,
   see #6
 
+* The Qiskit tests are run using local simulators. There are no tests that access the IBM Quantum backends. 
+
 * All the tests are run with the new operator arithmetic enabled. To check that the functionality of the
 legacy operator arithmetic is maintained during the deprecation cycle, the PennyLane tests are also run
 regularly with the new operator arithmetic disabled:

--- a/README.md
+++ b/README.md
@@ -33,16 +33,6 @@ All entries in the matrix are tested against PennyLane latest (GitHub master).
 * The Braket plugin device integration tests are run with `-k “not Sample and not no_0_shots”`,
   see #6
 
-* The Qiskit tests above are run with `-k 'not test_ibmq.py and not test_runtime.py'`, that is,
-  without using devices that access the IBMQ backend. The IBMQ backend is tested via `test_ibmp.qpy`
-  and `test_runtime.py` tests on the latest version of Pennylane and the plugin twice a week.
-  Their status is shown below:
-
-|                                                                    | Status                                                                                                                                                                                                                             |
-| :----------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Qiskit-IBMQ](https://github.com/PennyLaneAI/pennylane-qiskit)     | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-qiskit/ibmq_tests.yml?branch=master)](https://github.com/PennyLaneAI/pennylane-qiskit/actions/workflows/ibmq_tests.yml)     |
-| [Qiskit-IBMQ 1.0](https://github.com/PennyLaneAI/pennylane-qiskit) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-qiskit/ibmq_tests_1.yml?branch=master)](https://github.com/PennyLaneAI/pennylane-qiskit/actions/workflows/ibmq_tests_1.yml) |
-
 * All the tests are run with the new operator arithmetic enabled. To check that the functionality of the
 legacy operator arithmetic is maintained during the deprecation cycle, the PennyLane tests are also run
 regularly with the new operator arithmetic disabled:

--- a/compile.py
+++ b/compile.py
@@ -15,6 +15,7 @@ workflows = [
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator",
         ],
+        "test_kwargs": ["-k 'not test_ibmq.py and not test_runtime.py'"],
         "token": "IBMQX_TOKEN",
     },
     {
@@ -51,14 +52,13 @@ workflows = [
             "--device=rigetti.wavefunction --tb=short --skip-ops --shots=20000",
             # "--device=rigetti.qvm --tb=short --skip-ops --shots=20000 --device-kwargs device=4q-qvm",
         ],
-        "additional_setup": dedent(
-            """
+        "additional_setup": dedent("""
             - name: Run Rigetti Quilc
               run: docker run --rm -d -p 5555:5555 rigetti/quilc:1.23.0 -R
 
             - name: Run Rigetti QVM
               run: docker run --rm -d -p 5000:5000 rigetti/qvm -S"""
-        ),
+        )
     },
     {
         "plugin": "aqt",
@@ -89,8 +89,7 @@ workflows = [
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",
-        "additional_setup": dedent(
-            """
+        "additional_setup": dedent("""
             - name: Install TF
               run: |
                 pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION"""
@@ -138,27 +137,19 @@ def render_templates():
         # PennyLane stable tests
         for i in wf["which"]:
             with open(f".github/workflows/{wf['plugin']}-{i}-stable.yml", "w") as f:
-                f.write(
-                    render_from_template(
-                        "workflow-template-stable.yml", latest=i == "latest", **wf
-                    )
-                )
+                f.write(render_from_template("workflow-template-stable.yml", latest=i ==  "latest", **wf))
 
         # PennyLane latest tests
         for i in wf["which"]:
             with open(f".github/workflows/{wf['plugin']}-{i}-latest.yml", "w") as f:
                 f.write(
-                    render_from_template(
-                        "workflow-template-latest.yml", latest=i == "latest", **wf
-                    )
+                    render_from_template("workflow-template-latest.yml", latest=i == "latest", **wf)
                 )
 
         # PennyLane release candidate tests
         with open(f".github/workflows/{wf['plugin']}-latest-rc.yml", "w") as f:
             f.write(
-                render_from_template(
-                    "workflow-template-release-candidate.yml", latest=True, **wf
-                )
+                render_from_template("workflow-template-release-candidate.yml", latest=True, **wf)
             )
 
 

--- a/compile.py
+++ b/compile.py
@@ -15,7 +15,6 @@ workflows = [
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator",
         ],
-        "test_kwargs": ["-k 'not test_ibmq.py and not test_runtime.py'"],
         "token": "IBMQX_TOKEN",
     },
     {

--- a/compile.py
+++ b/compile.py
@@ -15,7 +15,6 @@ workflows = [
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator",
             "--device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator",
         ],
-        "test_kwargs": ["-k 'not test_ibmq.py and not test_runtime.py'"],
         "token": "IBMQX_TOKEN",
     },
     {
@@ -52,13 +51,14 @@ workflows = [
             "--device=rigetti.wavefunction --tb=short --skip-ops --shots=20000",
             # "--device=rigetti.qvm --tb=short --skip-ops --shots=20000 --device-kwargs device=4q-qvm",
         ],
-        "additional_setup": dedent("""
+        "additional_setup": dedent(
+            """
             - name: Run Rigetti Quilc
               run: docker run --rm -d -p 5555:5555 rigetti/quilc:1.23.0 -R
 
             - name: Run Rigetti QVM
               run: docker run --rm -d -p 5000:5000 rigetti/qvm -S"""
-        )
+        ),
     },
     {
         "plugin": "aqt",
@@ -89,7 +89,8 @@ workflows = [
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",
-        "additional_setup": dedent("""
+        "additional_setup": dedent(
+            """
             - name: Install TF
               run: |
                 pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION"""
@@ -137,19 +138,27 @@ def render_templates():
         # PennyLane stable tests
         for i in wf["which"]:
             with open(f".github/workflows/{wf['plugin']}-{i}-stable.yml", "w") as f:
-                f.write(render_from_template("workflow-template-stable.yml", latest=i ==  "latest", **wf))
+                f.write(
+                    render_from_template(
+                        "workflow-template-stable.yml", latest=i == "latest", **wf
+                    )
+                )
 
         # PennyLane latest tests
         for i in wf["which"]:
             with open(f".github/workflows/{wf['plugin']}-{i}-latest.yml", "w") as f:
                 f.write(
-                    render_from_template("workflow-template-latest.yml", latest=i == "latest", **wf)
+                    render_from_template(
+                        "workflow-template-latest.yml", latest=i == "latest", **wf
+                    )
                 )
 
         # PennyLane release candidate tests
         with open(f".github/workflows/{wf['plugin']}-latest-rc.yml", "w") as f:
             f.write(
-                render_from_template("workflow-template-release-candidate.yml", latest=True, **wf)
+                render_from_template(
+                    "workflow-template-release-candidate.yml", latest=True, **wf
+                )
             )
 
 


### PR DESCRIPTION
The PL-Qiskit plugin no longer has tests that require an ibmq account. Namely `test_ibmq.py` and `test_runtime.py` have been deleted from the plugin CI tests and so are not relevant for the test matrix. This update accounts for the deletion of these tests and makes changes accordingly.

Related Issue:
[sc-69774]