### PR TITLE
Add badge for `update-dev` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ regularly with the new operator arithmetic disabled:
 | :---------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`build-branch-dev`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/build-branch-dev.yml)       | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/build-branch-dev.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/build-branch-dev.yml)       |
 | [`build-branch-master`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/build-branch-master.yml) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/build-branch-master.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/build-branch-master.yml) |
+| [`update-dev`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/update-dev.yml) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/update-dev.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/update-dev.yml) |
 
 ## Lightning Docker builds
 


### PR DESCRIPTION
`qml`'s `update-dev` action now has a badge under the "QML repo" section.

<img width="362" alt="image" src="https://github.com/user-attachments/assets/c79385c0-62e0-4dd6-a6cb-d0c5293e2f4a">

