### PR TITLE
Update workflows to checkout to correct tag for stable plugin tests

### DIFF
--- a/.github/workflows/aqt-latest-stable.yml
+++ b/.github/workflows/aqt-latest-stable.yml
@@ -52,6 +52,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       
 
       - name: Run plugin tests

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -58,7 +58,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -66,14 +66,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/aqt-stable-stable.yml
+++ b/.github/workflows/aqt-stable-stable.yml
@@ -66,14 +66,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       
 

--- a/.github/workflows/aqt-stable-stable.yml
+++ b/.github/workflows/aqt-stable-stable.yml
@@ -58,7 +58,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       
 
       - name: Run plugin tests

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -59,6 +59,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -65,7 +65,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -73,14 +73,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -65,7 +65,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -73,14 +73,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -54,6 +54,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -60,7 +60,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -68,14 +68,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -60,7 +60,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -68,14 +68,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/ionq-latest-stable.yml
+++ b/.github/workflows/ionq-latest-stable.yml
@@ -53,6 +53,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -59,7 +59,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -67,14 +67,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -59,7 +59,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -67,14 +67,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -55,6 +55,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -69,14 +69,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -44,7 +44,6 @@ jobs:
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark
-          pip install semantic-version
           pip freeze
 
       - name: Install PennyLane and Plugin
@@ -62,7 +61,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -61,7 +61,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -69,14 +69,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/quantuminspire-latest-stable.yml
+++ b/.github/workflows/quantuminspire-latest-stable.yml
@@ -56,6 +56,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/quantuminspire-stable-latest.yml
+++ b/.github/workflows/quantuminspire-stable-latest.yml
@@ -70,14 +70,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/quantuminspire-stable-latest.yml
+++ b/.github/workflows/quantuminspire-stable-latest.yml
@@ -62,7 +62,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/quantuminspire-stable-stable.yml
+++ b/.github/workflows/quantuminspire-stable-stable.yml
@@ -62,7 +62,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/quantuminspire-stable-stable.yml
+++ b/.github/workflows/quantuminspire-stable-stable.yml
@@ -70,14 +70,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qulacs-latest-stable.yml
+++ b/.github/workflows/qulacs-latest-stable.yml
@@ -53,6 +53,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -59,7 +59,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -67,14 +67,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/qulacs-stable-stable.yml
+++ b/.github/workflows/qulacs-stable-stable.yml
@@ -59,7 +59,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/qulacs-stable-stable.yml
+++ b/.github/workflows/qulacs-stable-stable.yml
@@ -67,14 +67,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/rigetti-latest-stable.yml
+++ b/.github/workflows/rigetti-latest-stable.yml
@@ -59,6 +59,7 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -65,7 +65,22 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -73,14 +73,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/.github/workflows/rigetti-stable-stable.yml
+++ b/.github/workflows/rigetti-stable-stable.yml
@@ -65,7 +65,23 @@ jobs:
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: v${{ steps.plugin-version.outputs.version }}
+          ref: ${{ env.PLUGIN_BRANCH }}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PLUGIN_REPO }}
+          path: plugin_repo
+          ref: ${{ steps.plugin-tag.outputs.version }}
+
       - name: Run PennyLane device integration tests
         run: |
           if ! [ -x "$(command -v pl-device-test)" ]; then

--- a/.github/workflows/rigetti-stable-stable.yml
+++ b/.github/workflows/rigetti-stable-stable.yml
@@ -73,14 +73,15 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout to the determined tag
         uses: actions/checkout@v2
         with:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
-          ref: ${{ steps.plugin-tag.outputs.version }}
+          ref: ${{ steps.plugin-tag.outputs.tag }}
 
       - name: Run PennyLane device integration tests
         run: |

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -61,7 +61,7 @@ jobs:
           pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
-     {%- if latest %}
+      {%- if latest %}
 
       - name: Install PennyLane and Plugin
         run: |
@@ -97,7 +97,24 @@ jobs:
         with:
           repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
           path: plugin_repo
-          ref: {% raw %}v${{ steps.plugin-version.outputs.version }}{% endraw %}
+          ref: {% raw %}${{ env.PLUGIN_BRANCH }}{% endraw %}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          {% raw -%}
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+          {%- endraw %}
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
+          path: plugin_repo
+          ref: {% raw %}${{ steps.plugin-tag.outputs.version }}{% endraw %}
 
       {% endif -%}
 

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -106,7 +106,8 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           {%- endraw %}
 
       - name: Checkout to the determined tag
@@ -114,7 +115,7 @@ jobs:
         with:
           repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
           path: plugin_repo
-          ref: {% raw %}${{ steps.plugin-tag.outputs.version }}{% endraw %}
+          ref: {% raw %}${{ steps.plugin-tag.outputs.tag }}{% endraw %}
 
       {% endif -%}
 

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -100,7 +100,8 @@ jobs:
           cd plugin_repo
           base_version="v${{ steps.plugin-version.outputs.version }}"
           TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo $TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           {%- endraw %}
 
       - name: Checkout to the determined tag
@@ -108,7 +109,7 @@ jobs:
         with:
           repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
           path: plugin_repo
-          ref: {% raw %}${{ steps.plugin-tag.outputs.version }}{% endraw %}
+          ref: {% raw %}${{ steps.plugin-tag.outputs.tag }}{% endraw %}
 
       {% endif -%}
 

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -56,7 +56,7 @@ jobs:
           pip install pytest-mock pytest-cov flaky pytest-benchmark
           pip freeze
 
-     {%- if latest %}
+      {%- if latest %}
 
       - name: Install PennyLane and Plugin
         run: |
@@ -69,6 +69,7 @@ jobs:
           repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
           path: plugin_repo
           ref: {% raw %}${{ env.PLUGIN_BRANCH }}{% endraw %}
+
       {% else %}
 
       - name: Install PennyLane and Plugin
@@ -90,7 +91,25 @@ jobs:
         with:
           repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
           path: plugin_repo
-          ref: {% raw %}v${{ steps.plugin-version.outputs.version }}{% endraw %}
+          ref: {% raw %}${{ env.PLUGIN_BRANCH }}{% endraw %}
+
+      - name: Get stable version tag
+        id: plugin-tag
+        run: |
+          {% raw -%}
+          cd plugin_repo
+          base_version="v${{ steps.plugin-version.outputs.version }}"
+          TAG=$(git tag | grep -E "^${base_version//./\\.}([.-]post[0-9]+)?$" | sort -V | tail -n 1)
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+          {%- endraw %}
+
+      - name: Checkout to the determined tag
+        uses: actions/checkout@v2
+        with:
+          repository: {% raw %}${{ env.PLUGIN_REPO }}{% endraw %}
+          path: plugin_repo
+          ref: {% raw %}${{ steps.plugin-tag.outputs.version }}{% endraw %}
+
       {% endif -%}
 
       {% if device_tests -%}


### PR DESCRIPTION
I added a couple of steps to the stable plugin test workflows so that when checking out to the plugin repo to access the tests, we checkout to the correct tag.

Correct tag in this context means the tag for the most recent stable release. If there is a postfix release, then the tag for the postfix release will be used.