### PR TITLE
Ignore specific deprecation warnings in stable-latest tests

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -58,4 +58,6 @@ jobs:
         run: |
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -64,4 +64,7 @@ jobs:
         run: |
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -67,4 +67,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -67,4 +67,5 @@ jobs:
           pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/test/unit_tests --tb=short
+        run: |
+          python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -73,4 +73,5 @@ jobs:
           pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/test/unit_tests --tb=short
+        run: |
+          python -m pytest plugin_repo/test/unit_tests --tb=short

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -66,4 +66,6 @@ jobs:
           pl-device-test --device=cirq.qsim --tb=short --skip-ops --analytic=False --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -72,4 +72,7 @@ jobs:
           pl-device-test --device=cirq.qsim --tb=short --skip-ops --analytic=False --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -75,4 +75,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -60,4 +60,6 @@ jobs:
           pl-device-test --device=ionq.simulator --tb=short --skip-ops --shots=10000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -66,4 +66,7 @@ jobs:
           pl-device-test --device=ionq.simulator --tb=short --skip-ops --shots=10000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -69,4 +69,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -65,4 +65,6 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -44,7 +44,6 @@ jobs:
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark
-          pip install semantic-version
           pip freeze
 
       - name: Install PennyLane and Plugin
@@ -72,4 +71,7 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -74,4 +74,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -61,4 +61,6 @@ jobs:
           pl-device-test --device=qulacs.simulator --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -70,4 +70,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -67,4 +67,7 @@ jobs:
           pl-device-test --device=qulacs.simulator --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/rigetti-latest-latest.yml
+++ b/.github/workflows/rigetti-latest-latest.yml
@@ -67,4 +67,6 @@ jobs:
           pl-device-test --device=rigetti.wavefunction --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -73,4 +73,7 @@ jobs:
           pl-device-test --device=rigetti.wavefunction --tb=short --skip-ops --shots=20000
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/tests -W "error::pennylane.PennyLaneDeprecationWarning" --tb=short
+        run: |
+          python -m pytest plugin_repo/tests --tb=short \
+          -W "error::pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -76,4 +76,5 @@ jobs:
         run: |
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -111,5 +111,6 @@ jobs:
         run: |
           python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }}{%- endfor %}{% if no_deprecation_error %}{% else %} \
           -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %}{% if latest or no_deprecation_error %}{% else %} \
-          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"{% endif %}
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"{% endif %}
 

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -108,5 +108,8 @@ jobs:
           {%- endfor %}
 
       - name: Run plugin tests
-        run: python -m pytest plugin_repo/{{ tests_loc }}{% if no_deprecation_error %}{% else %} -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }} {%- endfor %}
+        run: |
+          python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }}{%- endfor %}{% if no_deprecation_error %}{% else %} \
+          -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %}{% if latest or no_deprecation_error %}{% else %} \
+          -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning"{% endif %}
 


### PR DESCRIPTION
As name says. The latest version of the failing plugins have already been updated to no longer use the deprecated code, so we're left with false positives in the stable-latest tests. This PR suppresses the `QubitDevice` and `QubitStateVector` deprecation warnings for the stable-latest tests.

Note that the latest-latest test workflows have also been updated because I made some formatting changes to the template file. These changes are superficial and don't change the latest-latest tests in any way.