### PR TITLE
Suppress Tensor deprecation warnings in `stable-latest` tests

### DIFF
--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -68,4 +68,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -76,4 +76,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -70,4 +70,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -75,4 +75,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -71,4 +71,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/.github/workflows/rigetti-stable-latest.yml
+++ b/.github/workflows/rigetti-stable-latest.yml
@@ -77,4 +77,5 @@ jobs:
           python -m pytest plugin_repo/tests --tb=short \
           -W "error::pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -112,5 +112,6 @@ jobs:
           python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }}{%- endfor %}{% if no_deprecation_error %}{% else %} \
           -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %}{% if latest or no_deprecation_error %}{% else %} \
           -W "ignore:QubitDevice:pennylane.PennyLaneDeprecationWarning" \
+          -W "ignore:qml.operation.Tensor:pennylane.PennyLaneDeprecationWarning" \
           -W "ignore:QubitStateVector:pennylane.PennyLaneDeprecationWarning"{% endif %}
 


### PR DESCRIPTION
As name says. Deprecated code present in the stable version of some plugins is causing deprecation warnings to be raised, which might cause other errors to be hidden, so I've updated the stable-latest tests to suppress even more pennylane deprecation warnings, specifically the `Tensor` deprecation.