### PR TITLE
pinning `qiskit` to version `<1.3`

### DIFF
--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade 'qiskit<1.3'
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade 'qiskit<1.3'
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0'  
           pip install pytest-mock pytest-cov flaky pytest-benchmark

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade 'qiskit<1.3'
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade 'qiskit<1.3'
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install --upgrade qiskit
+          pip install --upgrade 'qiskit<1.3'
           pip install --upgrade pyscf
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark


### PR DESCRIPTION
We pinned `qiskit` to version `<1.3` in the `requirements.txt` file of the `pennylane-qiskit` repository.
See [this PR](https://github.com/PennyLaneAI/pennylane-qiskit/pull/603).

However, in the `plugin-test-matrix`, `qiskit` is not installed from the file above but within the GitHub workflows related to `qiskit`.

Therefore, to have a green CI in the plugin test matrix we need to pin `qiskit` in the relevant workflows of the `plugin-test-matrix` repository. 