### PR TITLE
Fix lightning-latest-rc kokkos failure

### DIFF
--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           cd plugin_repo
           SKIP_COMPILATION=True PL_BACKEND=lightning_qubit pip install . -vv
+          PL_BACKEND=${{ matrix.pl_backend }} python scripts/configure_pyproject_toml.py
           PL_BACKEND=${{ matrix.pl_backend }} pip install . -vv
 
       - name: Run PennyLane device integration tests


### PR DESCRIPTION
This PR fixes the issue that Lightning Kokkos was not installed due to missing a step to update the pyproject toml, resulting in failed test. 