### PR TITLE
Switch from `Python 3.10` to `Python 3.11` for `Cirq`

### DIFF
--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Install requirements
         run: |
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade pip
           pip install --upgrade cirq
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade cirq
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark
-          pip install qcs-sdk-python==0.21.12
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -43,6 +43,7 @@ jobs:
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 
           pip install pytest-mock pytest-cov flaky pytest-benchmark
+          pip install qcs-sdk-python==0.21.12
           pip freeze
 
       - name: Install PennyLane and Plugin

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -34,12 +34,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade pip
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0'  

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -34,12 +34,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0'  

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -34,12 +34,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -34,12 +34,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -34,12 +34,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          pip install qcs-sdk-python==0.21.12
           pip install --upgrade cirq
           pip install --upgrade qsimcirq
           pip install 'pytest<8.1.0' 


### PR DESCRIPTION
`pip install cirq` is broken for Python3.10 due to the rigetti dependency having issues with the CRC of the compiled module.

Therefore, we perform the checks associated with `cirq` using `Python 3.11` instead.

[sc-85836]