### PR TITLE
Bumping version in plugins as preparation to PL 0.41 release

### DIFF
--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install PennyLane
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install PennyLane and Plugin
         run: |
           {% raw -%}
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.40.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
           {%- endraw %}
 


### PR DESCRIPTION
Updating the Feature Freeze Testing Matrix on the plugin test matrix page to point to the upcoming release candidate. 

1) Currently, all the `{plugin}-rc / tests` checks are failing, because the `v0.41.0-rc0` PennyLane branch still has not been created. This will be created next week. For the timeline, I am simply following the steps in the recommended order reported [in the guidelines](https://github.com/PennyLaneAI/guidance-docs/blob/automate-pr-collection/development/pennylane-release.md#prepare-the-feature-freeze-test-matrix). In particular, the preparation of the Feature Freeze matrix is supposed to take place the week *before* feature freeze. That is, before the creation of the `rc` branch.

2) Notice that `cirq` is still tested with Python 11 instead of 10, due to the issue discussed in [this PR](https://github.com/PennyLaneAI/plugin-test-matrix/pull/103) and the associated ShortCut story,

[sc-87418]