### PR TITLE
Add scheduled dev and master builds to QML test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ All entries in the matrix are tested against PennyLane latest (GitHub master).
 
 ## QML repo
 
+#### Pipeline V1
+
 |                                                                                                                   | Status                                                                                                                                                                                                   |
 | :---------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`build-branch-dev`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/build-branch-dev.yml)       | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/build-branch-dev.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/build-branch-dev.yml)       |
 | [`build-branch-master`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/build-branch-master.yml) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/build-branch-master.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/build-branch-master.yml) |
 | [`update-dev`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/update-dev.yml) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/update-dev.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/update-dev.yml) |
+
+#### Pipeline V2
+
+|                                                                                                                   | Status                                                                                                                                                                                                   |
+| :---------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`v2-build-branch-dev`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/v2-build-branch-dev.yml)       | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/v2-build-branch-dev.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/v2-build-branch-dev.yml)       |
+| [`v2-build-branch-master`](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/v2-build-branch-master.yml) | [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PennyLaneAI/qml/v2-build-branch-master.yml)](https://github.com/PennyLaneAI/qml/actions/workflows/v2-build-branch-master.yml) |
 
 ## Lightning Docker builds
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include information about new V2 pipelines, alongside the existing V1 pipelines, for better documentation of CI workflows.

Documentation updates:

* Added a new "V2 Pipelines" section with links and status badges for `v2-build-branch-dev` and `v2-build-branch-master` workflows, ensuring visibility of the new CI pipelines. (`README.md`, [README.mdR39-R53](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R53))