### PR TITLE
Prepare feature freeze test matrix

### DIFF
--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install requirements
         run: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq-latest-stable.yml
+++ b/.github/workflows/cirq-latest-stable.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/cirq-stable-stable.yml
+++ b/.github/workflows/cirq-stable-stable.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install PennyLane
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install PennyLane and Plugin
         run: |
           {% raw -%}
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.41.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
           {%- endraw %}
 


### PR DESCRIPTION
07-04-25: ~~NOTE: CI is failing since the RC branch won't be created until next week (I'm just following the guide's timeline 🤣 ).~~ 
07-07-25: rc branches were created.

This PR was generated with the following steps,

1. Manually update `workflow-template-release-candidate.yml`
2. Use `python compile.py` to automatically change remaining workflows
3. Manually update `lightning-latest.yml`

⚠️  Some `cirq` files that are not related to `rc` were changed. This is due to a temporary patch we did last release where we tested all of `cirq` against `3.11`.

[sc-94459]