### PR TITLE
Fix `lightning-latest-rc` on FF testing matrix

### DIFF
--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -48,7 +48,7 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade pybind11
           pip install 'pytest<8.1.0'
-          pip install pytest-mock pytest-cov flaky pytest-benchmark
+          pip install pytest-mock pytest-cov pytest-rng flaky pytest-benchmark
           pip freeze
 
       - name: Install PennyLane


### PR DESCRIPTION
Getting [failures](https://github.com/PennyLaneAI/plugin-test-matrix/actions/workflows/lightning-latest-rc.yml) in the Feature Freeze testing matrix for lightning `latest-rc`. Adding `pytest-rng` support should fix it!