### PR TITLE
Use new `pennylane.exceptions` module

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/cirq-latest-latest.yml
+++ b/.github/workflows/cirq-latest-latest.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/cirq-stable-latest.yml
+++ b/.github/workflows/cirq-stable-latest.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-latest-latest.yml
+++ b/.github/workflows/ionq-latest-latest.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/ionq-stable-latest.yml
+++ b/.github/workflows/ionq-stable-latest.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-latest-latest.yml
+++ b/.github/workflows/qiskit-latest-latest.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/qiskit-stable-latest.yml
+++ b/.github/workflows/qiskit-stable-latest.yml
@@ -73,4 +73,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-latest-latest.yml
+++ b/.github/workflows/qulacs-latest-latest.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/.github/workflows/qulacs-stable-latest.yml
+++ b/.github/workflows/qulacs-stable-latest.yml
@@ -69,4 +69,4 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \
-          -W "error::pennylane.PennyLaneDeprecationWarning"
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ The following table shows the current Catalyst compatibility with the Lightning 
   <td><a href=https://github.com/PennyLaneAI/pennylane/actions/workflows/package_warnings_as_errors.yml><img src=https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FPennyLaneAI%2Fplugin-test-matrix%2Frefs%2Ftags%2Fwae_data_tag%2Funique_wae.json&query=%24.%5B0%5D.%5B%22FutureWarning%22%5D&label=&color=9c6700></td>
 </tr>
 <tr>
-  <td><code>pennylane.PennyLaneDeprecationWarning</code></td>
-  <td><a href=https://github.com/PennyLaneAI/pennylane/actions/workflows/package_warnings_as_errors.yml><img src=https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FPennyLaneAI%2Fplugin-test-matrix%2Frefs%2Ftags%2Fwae_data_tag%2Funique_wae.json&query=%24.%5B0%5D.%5B%22pennylane.PennyLaneDeprecationWarning%22%5D&label=&color=9c6700></td>
+  <td><code>pennylane.exceptions.PennyLaneDeprecationWarning</code></td>
+  <td><a href=https://github.com/PennyLaneAI/pennylane/actions/workflows/package_warnings_as_errors.yml><img src=https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FPennyLaneAI%2Fplugin-test-matrix%2Frefs%2Ftags%2Fwae_data_tag%2Funique_wae.json&query=%24.%5B0%5D.%5B%22pennylane.exceptions.PennyLaneDeprecationWarning%22%5D&label=&color=9c6700></td>
 </tr>
 </table>
 

--- a/workflow-template-latest.yml
+++ b/workflow-template-latest.yml
@@ -110,5 +110,5 @@ jobs:
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/{{ tests_loc }} --tb=short {%- for kwarg in test_kwargs %} {{ kwarg }}{%- endfor %}{% if no_deprecation_error %}{% else %} \
-          -W "error::pennylane.PennyLaneDeprecationWarning"{% endif %}
+          -W "error::pennylane.exceptions.PennyLaneDeprecationWarning"{% endif %}
 


### PR DESCRIPTION
https://github.com/PennyLaneAI/pennylane/pull/7874 removed top level access to this exception. Instead it should be pulled from the `exceptions` module.

[sc-95787]