### PR TITLE
[v0.43 release] update rc branch version in FF plug-in test matrix

### DIFF
--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq-latest-rc.yml
+++ b/.github/workflows/cirq-latest-rc.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ionq-latest-rc.yml
+++ b/.github/workflows/ionq-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/lightning-latest-rc.yml
+++ b/.github/workflows/lightning-latest-rc.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install PennyLane
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/qiskit-latest-rc.yml
+++ b/.github/workflows/qiskit-latest-rc.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/qulacs-latest-rc.yml
+++ b/.github/workflows/qulacs-latest-rc.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install PennyLane and Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
 
       - uses: actions/checkout@v2

--- a/workflow-template-release-candidate.yml
+++ b/workflow-template-release-candidate.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install PennyLane and Plugin
         run: |
           {% raw -%}
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.42.0-rc0 \
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.43.0-rc0 \
             git+https://github.com/${{ env.PLUGIN_REPO }}.git@${{ env.PLUGIN_BRANCH }}
           {%- endraw %}
 


### PR DESCRIPTION
10-03-25: NOTE: CI is failing since the RC branch won't be created until next week

This PR was generated with the following steps,

1. Manually update `workflow-template-release-candidate.yml` (0.42 -> 0.43)
2. Use `python compile.py` to automatically change remaining workflows
3. Manually update `lightning-latest-rc.yml`

[sc-100777]