### PR TITLE
clean up unused tests

### DIFF
--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
-  AQT_TOKEN: ${{ secrets.AQT_TOKEN }}
 
 
 jobs:
@@ -54,8 +53,6 @@ jobs:
           repository: ${{ env.PLUGIN_REPO }}
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
-
-      
 
       - name: Run plugin tests
         run: |

--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -54,9 +54,6 @@ jobs:
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
 
-      - name: Run PennyLane device integration tests
-        run: |
-
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \

--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -54,6 +54,9 @@ jobs:
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
 
+      - name: Set up AQT API key
+        run: echo "AQT_API_KEY=${{ secrets.AQT_API_KEY }}" >> $GITHUB_ENV
+
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \

--- a/.github/workflows/aqt-latest-latest.yml
+++ b/.github/workflows/aqt-latest-latest.yml
@@ -16,6 +16,7 @@ env:
   PLUGIN_BRANCH: master
   PLUGIN_PACKAGE: pennylane_aqt
   PENNYLANE_BRANCH: master
+  AQT_TOKEN: ${{ secrets.AQT_TOKEN }}
 
 
 jobs:
@@ -54,8 +55,7 @@ jobs:
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
 
-      - name: Set up AQT API key
-        run: echo "AQT_API_KEY=${{ secrets.AQT_API_KEY }}" >> $GITHUB_ENV
+      
 
       - name: Run plugin tests
         run: |

--- a/.github/workflows/aqt-latest-rc.yml
+++ b/.github/workflows/aqt-latest-rc.yml
@@ -54,8 +54,5 @@ jobs:
           path: plugin_repo
           ref: ${{ env.PLUGIN_BRANCH }}
 
-      - name: Run PennyLane device integration tests
-        run: |
-
       - name: Run plugin tests
         run: python -m pytest plugin_repo/tests --tb=short

--- a/.github/workflows/aqt-stable-latest.yml
+++ b/.github/workflows/aqt-stable-latest.yml
@@ -60,9 +60,6 @@ jobs:
           path: plugin_repo
           ref: v${{ steps.plugin-version.outputs.version }}
 
-      - name: Run PennyLane device integration tests
-        run: |
-
       - name: Run plugin tests
         run: |
           python -m pytest plugin_repo/tests --tb=short \

--- a/compile.py
+++ b/compile.py
@@ -47,6 +47,7 @@ workflows = [
         "which": ["stable", "latest"],
         "requirements": [],
         "device_tests": [],
+        "token": "AQT_TOKEN",
     },
     {
         "plugin": "ionq",

--- a/compile.py
+++ b/compile.py
@@ -47,7 +47,6 @@ workflows = [
         "which": ["stable", "latest"],
         "requirements": [],
         "device_tests": [],
-        "token": "AQT_TOKEN",
     },
     {
         "plugin": "ionq",


### PR DESCRIPTION
`Run PennyLane device integration tests` in the three .yml workflows of aqt is literally empty. We should delete them if not used atl