### PR TITLE
Remove TensorFlow from Braket workflows

### DIFF
--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
   TORCH_VERSION: 2.0.0+cpu
   JAX_VERSION: 0.4.28
 
@@ -39,10 +38,6 @@ jobs:
         with:
           python-version: "3.12"
             
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
   TORCH_VERSION: 2.0.0+cpu
   JAX_VERSION: 0.4.28
 
@@ -39,10 +38,6 @@ jobs:
         with:
           python-version: "3.12"
             
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
   TORCH_VERSION: 2.0.0+cpu
   JAX_VERSION: 0.4.28
 
@@ -39,10 +38,6 @@ jobs:
         with:
           python-version: "3.11"
             
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
   TORCH_VERSION: 2.0.0+cpu
   JAX_VERSION: 0.4.28
 
@@ -39,10 +38,6 @@ jobs:
         with:
           python-version: "3.12"
             
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -16,7 +16,6 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
   TORCH_VERSION: 2.0.0+cpu
   JAX_VERSION: 0.4.28
 
@@ -39,10 +38,6 @@ jobs:
         with:
           python-version: "3.11"
             
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/compile.py
+++ b/compile.py
@@ -71,16 +71,11 @@ workflows = [
         ],
         "tests_loc": "test/unit_tests",
         "additional_setup": dedent("""
-            - name: Install TF
-              run: |
-                pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-                                   
             - name: Install JAX
               run: |
                 pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION"""
-                                   
         ),
-        "additional_env_vars": "TF_VERSION: 2.12.0\n  TORCH_VERSION: 2.0.0+cpu\n  JAX_VERSION: 0.4.28",
+        "additional_env_vars": "TORCH_VERSION: 2.0.0+cpu\n  JAX_VERSION: 0.4.28",
         "no_deprecation_error": True,
     },
 ]


### PR DESCRIPTION
## Summary

- remove the TensorFlow installation step from all generated Braket workflows
- remove the unused `TF_VERSION` environment variable
- retain the existing JAX setup and all Braket test coverage

## Root cause

PR #124 exposed that every Braket matrix job fails before tests because Python 3.12 cannot install the pinned `tensorflow~=2.12.0`. PTM does not require TensorFlow coverage, so the installation is unnecessary.

Failing example: https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/29522453557/job/87702528302?pr=124

## Validation

- `python3 compile.py`
- `python3 -m py_compile compile.py`
- confirmed a second generator run produces an identical diff
- confirmed no `Install TF`, `tensorflow`, `keras`, or `TF_VERSION` references remain in the Braket workflow source or generated workflows
- `git -c core.whitespace=cr-at-eol diff --check`