### PR TITLE
miscs: remove `tf`; maintain `torch`; and the remaining `3.11` drop

### DIFF
--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -38,10 +38,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-            
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install JAX
         run: |

--- a/.github/workflows/braket-latest-latest.yml
+++ b/.github/workflows/braket-latest-latest.yml
@@ -16,9 +16,8 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
-  TORCH_VERSION: 2.0.0+cpu
-  JAX_VERSION: 0.4.28
+  TORCH_VERSION: 2.9.1+cpu
+  JAX_VERSION: 0.7.1
 
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-
+            
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -38,10 +38,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-            
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install JAX
         run: |

--- a/.github/workflows/braket-latest-rc.yml
+++ b/.github/workflows/braket-latest-rc.yml
@@ -16,9 +16,8 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
-  TORCH_VERSION: 2.0.0+cpu
-  JAX_VERSION: 0.4.28
+  TORCH_VERSION: 2.9.1+cpu
+  JAX_VERSION: 0.7.1
 
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-
+            
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -16,9 +16,8 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
-  TORCH_VERSION: 2.0.0+cpu
-  JAX_VERSION: 0.4.28
+  TORCH_VERSION: 2.9.1+cpu
+  JAX_VERSION: 0.7.1
 
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-
+            
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-latest-stable.yml
+++ b/.github/workflows/braket-latest-stable.yml
@@ -37,11 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
-            
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
+          python-version: "3.12"
 
       - name: Install JAX
         run: |

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -38,10 +38,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-            
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install JAX
         run: |

--- a/.github/workflows/braket-stable-latest.yml
+++ b/.github/workflows/braket-stable-latest.yml
@@ -16,9 +16,8 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
-  TORCH_VERSION: 2.0.0+cpu
-  JAX_VERSION: 0.4.28
+  TORCH_VERSION: 2.9.1+cpu
+  JAX_VERSION: 0.7.1
 
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-
+            
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -16,9 +16,8 @@ env:
   PLUGIN_BRANCH: main
   PLUGIN_PACKAGE: amazon-braket-pennylane-plugin
   PENNYLANE_BRANCH: main
-  TF_VERSION: 2.12.0
-  TORCH_VERSION: 2.0.0+cpu
-  JAX_VERSION: 0.4.28
+  TORCH_VERSION: 2.9.1+cpu
+  JAX_VERSION: 0.7.1
 
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.12"
-
+            
       - name: Install JAX
         run: |
           pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION

--- a/.github/workflows/braket-stable-stable.yml
+++ b/.github/workflows/braket-stable-stable.yml
@@ -37,11 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
-            
-      - name: Install TF
-        run: |
-          pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
+          python-version: "3.12"
 
       - name: Install JAX
         run: |

--- a/.github/workflows/ionq-latest-stable.yml
+++ b/.github/workflows/ionq-latest-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/ionq-stable-stable.yml
+++ b/.github/workflows/ionq-stable-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/qiskit-latest-stable.yml
+++ b/.github/workflows/qiskit-latest-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/qiskit-stable-stable.yml
+++ b/.github/workflows/qiskit-stable-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: |

--- a/compile.py
+++ b/compile.py
@@ -49,7 +49,7 @@ workflows = [
                 pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION"""
                                    
         ),
-        "additional_env_vars": "TF_VERSION: 2.12.0\n  TORCH_VERSION: 2.0.0+cpu\n  JAX_VERSION: 0.4.28",
+        "additional_env_vars": "TF_VERSION: 2.12.0\n  TORCH_VERSION: 2.9.1+cpu\n  JAX_VERSION: 0.7.1",
         "no_deprecation_error": True,
     },
 ]

--- a/compile.py
+++ b/compile.py
@@ -39,17 +39,13 @@ workflows = [
             "--device=braket.local.qubit --tb=short --skip-ops -k 'not Sample and not no_0_shots'",
         ],
         "tests_loc": "test/unit_tests",
-        "additional_setup": dedent("""
-            - name: Install TF
-              run: |
-                pip install tensorflow~=$TF_VERSION keras~=$TF_VERSION
-                                   
+        "additional_setup": dedent("""                                   
             - name: Install JAX
               run: |
                 pip install jax==$JAX_VERSION jaxlib==$JAX_VERSION"""
                                    
         ),
-        "additional_env_vars": "TF_VERSION: 2.12.0\n  TORCH_VERSION: 2.9.1+cpu\n  JAX_VERSION: 0.7.1",
+        "additional_env_vars": "TORCH_VERSION: 2.9.1+cpu\n  JAX_VERSION: 0.7.1",
         "no_deprecation_error": True,
     },
 ]

--- a/workflow-template-stable.yml
+++ b/workflow-template-stable.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
 {%- if additional_setup is defined %}
       {{ additional_setup | indent(6, True) }}


### PR DESCRIPTION
Last round only cleared 3.11 for those touching latest pennylane. Now let's switch to 3.12 for all.

Torch: 2.9.1
Jax: 0.7.1